### PR TITLE
Remove JAVA_HOME override for OS X which defaults to using 1.5.0 JVM

### DIFF
--- a/res/unix/run.sh
+++ b/res/unix/run.sh
@@ -154,12 +154,6 @@ case "$DIST_OS" in
         ;;
     'darwin' | 'oarwin')
         DIST_OS="macosx"
-	
-	#We use the 1.5 jvm if it exists
-	if [ -d /System/Library/Frameworks/JavaVM.framework/Versions/1.5.0/ ]
-	then
-		export JAVA_HOME="/System/Library/Frameworks/JavaVM.framework/Versions/1.5.0/Home"
-	fi
         ;;
     'unix_sv')
         DIST_OS="unixware"


### PR DESCRIPTION
As mentioned on the mailing list, removing this code allows OS X to use the latest version of Java installed (or whatever CurrentJDK is pointing at) rather than forcing it to use 1.5.0_x (which is most likely out of date now).

I think this probably made sense a while ago as, IIRC, OS X shipped with 1.4 as the default even though 1.5 may have been available and not many users would know or care how to repoint the CurrentJDK symlink.  I don't think this case is relevant any more as installing java updates now appear to update the CurrentJDK link correctly, also using this should allow for more options (e.g. the user can point currentjdk at another jvm installation if they so wish).
