### PR TITLE
Fix for run.sh JAVA_HOME detection on Mac

### DIFF
--- a/res/unix/run.sh
+++ b/res/unix/run.sh
@@ -82,7 +82,7 @@ if [ "$DIST_OS" = "macosx" ]
 then
 	# If there's a modern (1.8+) JVM, use that...
 	JAVA_HOME="/Library/Internet Plug-Ins/JavaAppletPlugin.plugin/Contents/Home/"
-	if test -ne $JAVA_HOME/bin/java
+	if test -e "$JAVA_HOME/bin/java"
 	then
 		# otherwise hope for the best
 		JAVA_HOME="`/usr/libexec/java_home -v 1.6+`"

--- a/res/unix/run.sh
+++ b/res/unix/run.sh
@@ -82,7 +82,7 @@ if [ "$DIST_OS" = "macosx" ]
 then
 	# If there's a modern (1.8+) JVM, use that...
 	JAVA_HOME="/Library/Internet Plug-Ins/JavaAppletPlugin.plugin/Contents/Home/"
-	if test -e "$JAVA_HOME/bin/java"
+	if ! test -e "$JAVA_HOME/bin/java"
 	then
 		# otherwise hope for the best
 		JAVA_HOME="`/usr/libexec/java_home -v 1.6+`"


### PR DESCRIPTION
On OS X, the JAVA_HOME path detection in run.sh fails during installation and afterward with this error:

    /Applications/Freenet/run.sh: line 85: test: /Library/Internet: binary operator expected

This is probably a fatal error for anyone with just Oracle JRE7/8 installed, as the fallback method for finding JAVA_HOME on OS X when this test fails (running `/usr/libexec/java_home`) doesn't seem to work unless Apple Java 6 or Oracle JDK7/8 are installed