### PR TITLE
Ensure that the update.sh script does not break on update

### DIFF
--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -10,6 +10,10 @@ then
 	fi
 fi
 
+# ensure that this script is not overwritten (the shell sticks to the inode)
+mv "$0" "$0".old
+cp -p "$0".old "$0" # preserve permissions
+
 WHEREAMI="`pwd`"
 CAFILE="startssl.pem"
 JOPTS="-Djava.net.preferIPv4Stack=true"

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -10,9 +10,8 @@ then
 	fi
 fi
 
-# ensure that this script is not overwritten (the shell sticks to the inode)
-mv "$0" "$0".old
-cp -p "$0".old "$0" # preserve permissions
+# avoid changing the running script (the shell sticks to the inode)
+mv "$0" "$0".old && cp -p "$0".old "$0"
 
 WHEREAMI="`pwd`"
 CAFILE="startssl.pem"


### PR DESCRIPTION
This avoids breakage by ensuring that update.sh is not on the same inode as the currently executing script.
