### PR TITLE
Remove deprecated workaround

### DIFF
--- a/res/unix/run.sh
+++ b/res/unix/run.sh
@@ -280,8 +280,6 @@ then
 else
     if [ "$DIST_OS" = "macosx" ] # Some osx weirdness, someone please check that this still works
     then
-	# We don't have a binary for OS/X on 64-bit at present.
-	DIST_BIT="32"
         WRAPPER_TEST_CMD="$WRAPPER_CMD-$DIST_OS-universal-$DIST_BIT"
         if [ -x "$WRAPPER_TEST_CMD" ]
         then


### PR DESCRIPTION
It seems we currently have a [64 bit binary](https://github.com/freenet/fred/blob/34eadaff82d7ead04e18521d50ee478a0e4d0a40/dependencies.properties#L141) for Mac OS.